### PR TITLE
Done level 9, issue with applying le_antisymm in level 10

### DIFF
--- a/Game/Levels/FilterWorld/L09_principal_mono.lean
+++ b/Game/Levels/FilterWorld/L09_principal_mono.lean
@@ -19,23 +19,20 @@ TheoremTab "Filter"
 /-- If `A` and `B` are subsets of `𝓧` then `𝓟 A ≤ 𝓟 B ↔ A ⊆ B` . -/
 TheoremDoc MyGame.principal_mono as "principal_mono" in "Filter"
 
--- **TODO** needs human-readable proof, or explanation of tauto?
 /--  If `A` and `B` are subsets of `𝓧` then `𝓟 A ≤ 𝓟 B ↔ A ⊆ B` . -/
 Statement principal_mono {A B : Set 𝓧} : 𝓟 A ≤ 𝓟 B ↔ A ⊆ B := by
 constructor
-rw[le_def] at *
+Hint "Try `intro h`"
 intro h
-specialize h A
-rw [mem_principal] at h
-rw [mem_principal] at h
-intro x
-rw [subset_def] at h
-specialize h 
-sorry
-sorry
+apply h
+exact mem_principal_self B
+Hint "Try `intro h`"
+intro h
+Hint "use `intro S hS` and see if you can finish it off!"
+intro S hS
+rw [mem_principal] at *
+exact subset_trans h hS
 
-
-  
   
 
 Conclusion "The final thing we'll do this in world is to prove that if `𝓟 A = 𝓟 B` then `A = B`.

--- a/Game/Levels/FilterWorld/L10_principal_eq_iff_eq.lean
+++ b/Game/Levels/FilterWorld/L10_principal_eq_iff_eq.lean
@@ -19,10 +19,19 @@ TheoremTab "Filter"
 /-- If `A` and `B` are subsets of `𝓧` then `𝓟 A ≤ 𝓟 B ↔ A ⊆ B`. -/
 TheoremDoc MyGame.principal_mono as "principal_mono" in "Filter"
 
--- **TODO** needs human-readable proof, or explanation of tauto?
 /--  If `A` and `B` are subsets of `𝓧` then `𝓟 A = 𝓟 B ↔ A = B`. -/
 Statement principal_eq_iff_eq {A B : Set 𝓧} : 𝓟 A = 𝓟 B ↔ A = B := by
-  sorry -- use antisymm and previous level and ext and hopefully that's it
+   -- use antisymm and previous level and ext and hopefully that's it
+   constructor
+   intro h
+   apply subset_antisymm
+   -- apply le_antisymm at h does not work for some reason
+   sorry
+   sorry
+   sorry
+
+   
+
 
 Conclusion "Congratulations, you've finished the first filter world! If you've already
 done function world then you can go on to pushing and pulling filters."


### PR DESCRIPTION
Level 9 also finished now - found a proof without `specialize`. Can't split up 𝓟 A = 𝓟 B using `le_antisymm` in level 10 as we only have a one way implication: ∀ {𝓧 : Type} {𝓕 𝓖 : Filter 𝓧}, 𝓕 ≤ 𝓖 → 𝓖 ≤ 𝓕 → 𝓕 = 𝓖. Not sure how else to go about it.  
